### PR TITLE
docs: add population data definition examples

### DIFF
--- a/DataProducts/test/lsipii/Figure/Population.json
+++ b/DataProducts/test/lsipii/Figure/Population.json
@@ -136,8 +136,9 @@
             "example": 5548241
           },
           "updatedAt": {
-            "title": "Datetime the data was last updated at. A datetime in RFC3339 date-time syntax",
+            "title": "Datetime the data was last updated at",
             "type": "string",
+            "description": "A datetime in RFC3339 date-time syntax",
             "format": "date-time",
             "default": "",
             "example": "2022-06-17T11:52:00Z"

--- a/DataProducts/test/lsipii/Figure/Population.json
+++ b/DataProducts/test/lsipii/Figure/Population.json
@@ -121,22 +121,26 @@
           "description": {
             "title": "Data description",
             "type": "string",
-            "default": ""
+            "default": "",
+            "example": "Väkiluku, KOKO MAA, 2021"
           },
           "sourceName": {
             "title": "Data source name",
             "type": "string",
-            "default": ""
+            "default": "",
+            "example": "Tilastokeskus"
           },
           "population": {
             "title": "The population value",
-            "type": "integer"
+            "type": "integer",
+            "example": 5548241
           },
           "updatedAt": {
-            "title": "Data updated at datetime",
+            "title": "Datetime the data was last updated at. A datetime in RFC3339 date-time syntax",
             "type": "string",
             "format": "date-time",
-            "default": ""
+            "default": "",
+            "example": "2022-06-17T11:52:00Z"
           }
         }
       },

--- a/src/test/lsipii/Figure/Population.py
+++ b/src/test/lsipii/Figure/Population.py
@@ -12,7 +12,8 @@ class PopulationResponse(CamelCaseModel):
     population: int = Field(..., title="The population value", example=5548241)
     updated_at: datetime = Field(
         "",
-        title="Datetime the data was last updated at. A datetime in RFC3339 date-time syntax",
+        title="Datetime the data was last updated at",
+        description="A datetime in RFC3339 date-time syntax",
         example="2022-06-17T11:52:00Z",
     )
 

--- a/src/test/lsipii/Figure/Population.py
+++ b/src/test/lsipii/Figure/Population.py
@@ -5,10 +5,16 @@ from pydantic import Field
 
 
 class PopulationResponse(CamelCaseModel):
-    description: str = Field("", title="Data description")
-    source_name: str = Field("", title="Data source name")
-    population: int = Field(..., title="The population value")
-    updated_at: datetime = Field("", title="Data updated at datetime")
+    description: str = Field(
+        "", title="Data description", example="Väkiluku, KOKO MAA, 2021"
+    )
+    source_name: str = Field("", title="Data source name", example="Tilastokeskus")
+    population: int = Field(..., title="The population value", example=5548241)
+    updated_at: datetime = Field(
+        "",
+        title="Datetime the data was last updated at. A datetime in RFC3339 date-time syntax",
+        example="2022-06-17T11:52:00Z",
+    )
 
 
 class PopulationRequest(CamelCaseModel):


### PR DESCRIPTION
- Add data examples
- specify (with comments) the datetime syntax as it's defined in OpenAPI 3.0.3, date-time: 
    -  @see: https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#data-types
    - @see: https://www.rfc-editor.org/rfc/rfc3339#section-5.6