### PR TITLE
Create data product for user profile

### DIFF
--- a/DataProducts/test/lassipatanen/User/Profile.json
+++ b/DataProducts/test/lassipatanen/User/Profile.json
@@ -83,6 +83,12 @@
   },
   "components": {
     "schemas": {
+      "Gender": {
+        "title": "Gender",
+        "enum": ["MALE", "FEMALE"],
+        "type": "string",
+        "description": "An enumeration."
+      },
       "HTTPValidationError": {
         "title": "HTTPValidationError",
         "type": "object",
@@ -181,17 +187,25 @@
           },
           "gender": {
             "title": "Gender",
-            "type": "string",
-            "description": "Gender"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Gender"
+              }
+            ],
+            "description": "Gender of the user"
           },
           "countryOfBirthCode": {
             "title": "Country of birth code",
+            "maxLength": 2,
+            "minLength": 2,
             "type": "string",
             "description": "ISO 3166-1 alpha-2 code for country",
             "example": "FI"
           },
           "nativeLanguageCode": {
             "title": "Native language code",
+            "maxLength": 2,
+            "minLength": 2,
             "type": "string",
             "description": "ISO 3166-1 alpha-2 code for language",
             "example": "FI"
@@ -204,6 +218,8 @@
           },
           "citizenshipCode": {
             "title": "Nationality code",
+            "maxLength": 2,
+            "minLength": 2,
             "type": "string",
             "description": "ISO 3166-1 alpha-2 code for nationality",
             "example": "FI"

--- a/DataProducts/test/lassipatanen/User/Profile.json
+++ b/DataProducts/test/lassipatanen/User/Profile.json
@@ -1,0 +1,257 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "Basic user profile information",
+    "description": "Data product for basic user profile information",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/test/lassipatanen/User/Profile": {
+      "post": {
+        "summary": "test/lassipatanen/User/Profile",
+        "description": "User profile information",
+        "operationId": "request_test_lassipatanen_User_Profile",
+        "parameters": [
+          {
+            "description": "Optional consent token",
+            "required": false,
+            "schema": {
+              "title": "X-Consent-Token",
+              "type": "string",
+              "description": "Optional consent token"
+            },
+            "name": "x-consent-token",
+            "in": "header"
+          },
+          {
+            "description": "The login token. Value should be \"Bearer [token]\"",
+            "required": false,
+            "schema": {
+              "title": "Authorization",
+              "type": "string",
+              "description": "The login token. Value should be \"Bearer [token]\""
+            },
+            "name": "authorization",
+            "in": "header"
+          },
+          {
+            "description": "The bare domain of the system that provided the token.",
+            "required": false,
+            "schema": {
+              "title": "X-Authorization-Provider",
+              "type": "string",
+              "description": "The bare domain of the system that provided the token."
+            },
+            "name": "x-authorization-provider",
+            "in": "header"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProfileRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProfileResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "HTTPValidationError": {
+        "title": "HTTPValidationError",
+        "type": "object",
+        "properties": {
+          "detail": {
+            "title": "Detail",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            }
+          }
+        }
+      },
+      "ProfileRequest": {
+        "title": "ProfileRequest",
+        "type": "object",
+        "properties": {}
+      },
+      "ProfileResponse": {
+        "title": "ProfileResponse",
+        "required": [
+          "id",
+          "created",
+          "modified",
+          "firstName",
+          "lastName",
+          "address",
+          "immigrationDataConsent",
+          "jobsDataConsent",
+          "dateOfBirth",
+          "gender",
+          "countryOfBirthIsoCode",
+          "nativeLanguageIsoCode",
+          "occupationIsoCode",
+          "nationalityIsoCode"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string",
+            "description": "uuid formatted string used to identify users",
+            "format": "uuid",
+            "example": "cf57432e-809e-4353-adbd-9d5c0d733868"
+          },
+          "created": {
+            "title": "Created",
+            "type": "string",
+            "description": "Created at timestamp",
+            "format": "date-time",
+            "example": "2042-04-23T10:20:30.400"
+          },
+          "modified": {
+            "title": "Modified",
+            "type": "string",
+            "description": "Modified at timestamp",
+            "format": "date-time",
+            "example": "2042-04-23T10:20:30.400"
+          },
+          "firstName": {
+            "title": "First name",
+            "type": "string",
+            "description": "First name of the user"
+          },
+          "lastName": {
+            "title": "Last name",
+            "type": "string",
+            "description": "Last name of the user"
+          },
+          "address": {
+            "title": "Address",
+            "type": "string",
+            "description": "Address of the user"
+          },
+          "immigrationDataConsent": {
+            "title": "Immigration data consent",
+            "type": "boolean",
+            "description": "Has user given permission to use their data on Registration of Foreigners application",
+            "example": ["true", "false"]
+          },
+          "jobsDataConsent": {
+            "title": "Jobs data consent",
+            "type": "boolean",
+            "description": "Has user given permission to use their data on form application"
+          },
+          "dateOfBirth": {
+            "title": "Date of Birth",
+            "type": "string",
+            "description": "Date of Birth (date only)",
+            "format": "date",
+            "example": "1.1.2000"
+          },
+          "gender": {
+            "title": "Gender",
+            "type": "string",
+            "description": "Gender"
+          },
+          "countryOfBirthIsoCode": {
+            "title": "Country of Birth",
+            "type": "string",
+            "description": "ISO 3166-1 alpha-2 code for country",
+            "example": "FI"
+          },
+          "nativeLanguageIsoCode": {
+            "title": "Native language ISO code",
+            "type": "string",
+            "description": "ISO 3166-1 alpha-2 code for language",
+            "example": "FI"
+          },
+          "occupationIsoCode": {
+            "title": "Occupation code",
+            "type": "string",
+            "description": "Suomi.Fi code scheme"
+          },
+          "nationalityIsoCode": {
+            "title": "Nationality ISO code",
+            "type": "string",
+            "description": "ISO 3166-1 alpha-2 code for nationality",
+            "example": "FI"
+          },
+          "jobTitles": {
+            "title": "Job titles",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of job titles",
+            "example": ["Chef", "Programmer"]
+          },
+          "regions": {
+            "title": "Regions",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of regions where user would want to search for a job",
+            "example": ["Etelä-Suomi"]
+          }
+        }
+      },
+      "ValidationError": {
+        "title": "ValidationError",
+        "required": ["loc", "msg", "type"],
+        "type": "object",
+        "properties": {
+          "loc": {
+            "title": "Location",
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            }
+          },
+          "msg": {
+            "title": "Message",
+            "type": "string"
+          },
+          "type": {
+            "title": "Error Type",
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/DataProducts/test/lassipatanen/User/Profile.json
+++ b/DataProducts/test/lassipatanen/User/Profile.json
@@ -117,7 +117,8 @@
           "countryOfBirthCode",
           "nativeLanguageCode",
           "occupationCode",
-          "citizenshipCode"
+          "citizenshipCode",
+          "regions"
         ],
         "type": "object",
         "properties": {

--- a/DataProducts/test/lassipatanen/User/Profile.json
+++ b/DataProducts/test/lassipatanen/User/Profile.json
@@ -83,6 +83,39 @@
   },
   "components": {
     "schemas": {
+      "Address": {
+        "title": "Address",
+        "required": ["streetAddress", "zipCode", "city", "country"],
+        "type": "object",
+        "properties": {
+          "streetAddress": {
+            "title": "Street address",
+            "type": "string",
+            "description": "Street address",
+            "example": "Mannerheimintie 42"
+          },
+          "zipCode": {
+            "title": "ZIP code",
+            "maxLength": 5,
+            "minLength": 5,
+            "type": "string",
+            "description": "ZIP code of the address",
+            "example": "00100"
+          },
+          "city": {
+            "title": "City",
+            "type": "string",
+            "description": "City of the address location",
+            "example": "Helsinki"
+          },
+          "country": {
+            "title": "Country",
+            "type": "string",
+            "description": "Country of the address",
+            "example": "Suomi"
+          }
+        }
+      },
       "Gender": {
         "title": "Gender",
         "enum": ["MALE", "FEMALE"],
@@ -164,9 +197,12 @@
           },
           "address": {
             "title": "Address",
-            "type": "string",
-            "description": "Address of the user",
-            "example": "Paradise st. 13"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Address"
+              }
+            ],
+            "description": "Address of the user"
           },
           "immigrationDataConsent": {
             "title": "Immigration data consent",
@@ -207,13 +243,13 @@
             "maxLength": 2,
             "minLength": 2,
             "type": "string",
-            "description": "ISO 3166-1 alpha-2 code for language",
-            "example": "FI"
+            "description": "ISO 639-1 code for language",
+            "example": "fi"
           },
           "occupationCode": {
             "title": "Occupation code",
             "type": "string",
-            "description": "Suomi.Fi code scheme",
+            "description": "Code scheme for occupation. Full set of codes can be found at https://koodistot.suomi.fi/codelist-api/api/v1/coderegistries/jhs/codeschemes/ammatti_1_20100101/codes/",
             "example": "11122"
           },
           "citizenshipCode": {

--- a/DataProducts/test/lassipatanen/User/Profile.json
+++ b/DataProducts/test/lassipatanen/User/Profile.json
@@ -118,6 +118,7 @@
           "nativeLanguageCode",
           "occupationCode",
           "citizenshipCode",
+          "jobTitles",
           "regions"
         ],
         "type": "object",
@@ -146,28 +147,32 @@
           "firstName": {
             "title": "First name",
             "type": "string",
-            "description": "First name of the user"
+            "description": "First name of the user",
+            "example": "John"
           },
           "lastName": {
             "title": "Last name",
             "type": "string",
-            "description": "Last name of the user"
+            "description": "Last name of the user",
+            "example": "Doe"
           },
           "address": {
             "title": "Address",
             "type": "string",
-            "description": "Address of the user"
+            "description": "Address of the user",
+            "example": "Paradise st. 13"
           },
           "immigrationDataConsent": {
             "title": "Immigration data consent",
             "type": "boolean",
             "description": "Has user given permission to use their data on Registration of Foreigners application",
-            "example": ["true", "false"]
+            "example": "true"
           },
           "jobsDataConsent": {
             "title": "Jobs data consent",
             "type": "boolean",
-            "description": "Has user given permission to use their data on form application"
+            "description": "Has user given permission to use their data on form application",
+            "example": "false"
           },
           "dateOfBirth": {
             "title": "Date of birth",
@@ -196,7 +201,8 @@
           "occupationCode": {
             "title": "Occupation code",
             "type": "string",
-            "description": "Suomi.Fi code scheme"
+            "description": "Suomi.Fi code scheme",
+            "example": "11122"
           },
           "citizenshipCode": {
             "title": "Nationality code",

--- a/DataProducts/test/lassipatanen/User/Profile.json
+++ b/DataProducts/test/lassipatanen/User/Profile.json
@@ -114,10 +114,10 @@
           "jobsDataConsent",
           "dateOfBirth",
           "gender",
-          "countryOfBirthIsoCode",
-          "nativeLanguageIsoCode",
-          "occupationIsoCode",
-          "nationalityIsoCode"
+          "countryOfBirthCode",
+          "nativeLanguageCode",
+          "occupationCode",
+          "citizenshipCode"
         ],
         "type": "object",
         "properties": {
@@ -169,7 +169,7 @@
             "description": "Has user given permission to use their data on form application"
           },
           "dateOfBirth": {
-            "title": "Date of Birth",
+            "title": "Date of birth",
             "type": "string",
             "description": "Date of Birth (date only)",
             "format": "date",
@@ -180,25 +180,25 @@
             "type": "string",
             "description": "Gender"
           },
-          "countryOfBirthIsoCode": {
-            "title": "Country of Birth",
+          "countryOfBirthCode": {
+            "title": "Country of birth code",
             "type": "string",
             "description": "ISO 3166-1 alpha-2 code for country",
             "example": "FI"
           },
-          "nativeLanguageIsoCode": {
-            "title": "Native language ISO code",
+          "nativeLanguageCode": {
+            "title": "Native language code",
             "type": "string",
             "description": "ISO 3166-1 alpha-2 code for language",
             "example": "FI"
           },
-          "occupationIsoCode": {
+          "occupationCode": {
             "title": "Occupation code",
             "type": "string",
             "description": "Suomi.Fi code scheme"
           },
-          "nationalityIsoCode": {
-            "title": "Nationality ISO code",
+          "citizenshipCode": {
+            "title": "Nationality code",
             "type": "string",
             "description": "ISO 3166-1 alpha-2 code for nationality",
             "example": "FI"

--- a/DataProducts/test/lassipatanen/User/Profile.json
+++ b/DataProducts/test/lassipatanen/User/Profile.json
@@ -242,6 +242,7 @@
             "title": "Native language code",
             "maxLength": 2,
             "minLength": 2,
+            "pattern": "^[a-z]{2}$",
             "type": "string",
             "description": "ISO 639-1 code for language",
             "example": "fi"

--- a/DataProducts/test/lassipatanen/User/Profile.json
+++ b/DataProducts/test/lassipatanen/User/Profile.json
@@ -165,21 +165,19 @@
           "immigrationDataConsent": {
             "title": "Immigration data consent",
             "type": "boolean",
-            "description": "Has user given permission to use their data on Registration of Foreigners application",
-            "example": "true"
+            "description": "Has user given permission to use their data on Registration of Foreigners application"
           },
           "jobsDataConsent": {
             "title": "Jobs data consent",
             "type": "boolean",
-            "description": "Has user given permission to use their data on form application",
-            "example": "false"
+            "description": "Has user given permission to use their data on form application"
           },
           "dateOfBirth": {
             "title": "Date of birth",
             "type": "string",
             "description": "Date of Birth (date only)",
             "format": "date",
-            "example": "1.1.2000"
+            "example": "2000-01-01"
           },
           "gender": {
             "title": "Gender",

--- a/src/test/lassipatanen/User/Profile.py
+++ b/src/test/lassipatanen/User/Profile.py
@@ -23,18 +23,26 @@ class ProfileResponse(CamelCaseModel):
         example="2042-04-23T10:20:30.400",
     )
     first_name: Optional[str] = Field(
-        ..., title="First name", description="First name of the user"
+        ..., title="First name", description="First name of the user", example="John"
     )
-    last_name: str = Field(..., title="Last name", description="Last name of the user")
-    address: str = Field(..., title="Address", description="Address of the user")
+    last_name: str = Field(
+        ..., title="Last name", description="Last name of the user", example="Doe"
+    )
+    address: str = Field(
+        ...,
+        title="Address",
+        description="Address of the user",
+        example="Paradise st. 13",
+    )
     immigration_data_consent: bool = Field(
         title="Immigration data consent",
         description="Has user given permission to use their data on Registration of Foreigners application",
-        example=["true", "false"],
+        example="true",
     )
     jobs_data_consent: bool = Field(
         title="Jobs data consent",
         description="Has user given permission to use their data on form application",
+        example="false",
     )
     date_of_birth: date = Field(
         ...,
@@ -56,7 +64,10 @@ class ProfileResponse(CamelCaseModel):
         example="FI",
     )
     occupation_code: str = Field(
-        ..., title="Occupation code", description="Suomi.Fi code scheme"
+        ...,
+        title="Occupation code",
+        description="Suomi.Fi code scheme",
+        example="11122",
     )
     citizenship_code: str = Field(
         ...,
@@ -65,6 +76,7 @@ class ProfileResponse(CamelCaseModel):
         example="FI",
     )
     job_titles: Optional[List[str]] = Field(
+        ...,
         title="Job titles",
         description="List of job titles",
         example=["Chef", "Programmer"],

--- a/src/test/lassipatanen/User/Profile.py
+++ b/src/test/lassipatanen/User/Profile.py
@@ -37,18 +37,16 @@ class ProfileResponse(CamelCaseModel):
     immigration_data_consent: bool = Field(
         title="Immigration data consent",
         description="Has user given permission to use their data on Registration of Foreigners application",
-        example="true",
     )
     jobs_data_consent: bool = Field(
         title="Jobs data consent",
         description="Has user given permission to use their data on form application",
-        example="false",
     )
     date_of_birth: date = Field(
         ...,
         title="Date of birth",
         description="Date of Birth (date only)",
-        example="1.1.2000",
+        example="2000-01-01",
     )
     gender: str = Field(..., title="Gender", description="Gender")
     country_of_birth_code: str = Field(

--- a/src/test/lassipatanen/User/Profile.py
+++ b/src/test/lassipatanen/User/Profile.py
@@ -38,29 +38,29 @@ class ProfileResponse(CamelCaseModel):
     )
     date_of_birth: date = Field(
         ...,
-        title="Date of Birth",
+        title="Date of birth",
         description="Date of Birth (date only)",
         example="1.1.2000",
     )
     gender: str = Field(..., title="Gender", description="Gender")
-    country_of_birth_iso_code: str = Field(
+    country_of_birth_code: str = Field(
         ...,
-        title="Country of Birth",
+        title="Country of birth code",
         description="ISO 3166-1 alpha-2 code for country",
         example="FI",
     )
-    native_language_iso_code: str = Field(
+    native_language_code: str = Field(
         ...,
-        title="Native language ISO code",
+        title="Native language code",
         description="ISO 3166-1 alpha-2 code for language",
         example="FI",
     )
-    occupation_iso_code: str = Field(
+    occupation_code: str = Field(
         ..., title="Occupation code", description="Suomi.Fi code scheme"
     )
-    nationality_iso_code: str = Field(
+    citizenship_code: str = Field(
         ...,
-        title="Nationality ISO code",
+        title="Nationality code",
         description="ISO 3166-1 alpha-2 code for nationality",
         example="FI",
     )

--- a/src/test/lassipatanen/User/Profile.py
+++ b/src/test/lassipatanen/User/Profile.py
@@ -77,7 +77,9 @@ class ProfileResponse(CamelCaseModel):
         description="ISO 3166-1 alpha-2 code for country",
         example="FI",
     )
-    native_language_code: constr(min_length=2, max_length=2, to_lower=True) = Field(
+    native_language_code: constr(
+        min_length=2, max_length=2, to_lower=True, regex="^[a-z]{2}$"
+    ) = Field(
         ...,
         title="Native language code",
         description="ISO 639-1 code for language",

--- a/src/test/lassipatanen/User/Profile.py
+++ b/src/test/lassipatanen/User/Profile.py
@@ -12,6 +12,27 @@ class Gender(str, Enum):
     female = "FEMALE"
 
 
+class Address(CamelCaseModel):
+    street_address: str = Field(
+        ...,
+        title="Street address",
+        description="Street address",
+        example="Mannerheimintie 42",
+    )
+    zip_code: constr(min_length=5, max_length=5) = Field(
+        ..., title="ZIP code", description="ZIP code of the address", example="00100"
+    )
+    city: str = Field(
+        ...,
+        title="City",
+        description="City of the address location",
+        example="Helsinki",
+    )
+    country: str = Field(
+        ..., title="Country", description="Country of the address", example="Suomi"
+    )
+
+
 class ProfileResponse(CamelCaseModel):
     id: UUID = Field(
         title="Id",
@@ -34,12 +55,7 @@ class ProfileResponse(CamelCaseModel):
     last_name: str = Field(
         ..., title="Last name", description="Last name of the user", example="Doe"
     )
-    address: str = Field(
-        ...,
-        title="Address",
-        description="Address of the user",
-        example="Paradise st. 13",
-    )
+    address: Address = Field(..., title="Address", description="Address of the user")
     immigration_data_consent: bool = Field(
         title="Immigration data consent",
         description="Has user given permission to use their data on Registration of Foreigners application",
@@ -64,13 +80,13 @@ class ProfileResponse(CamelCaseModel):
     native_language_code: constr(min_length=2, max_length=2, to_upper=True) = Field(
         ...,
         title="Native language code",
-        description="ISO 3166-1 alpha-2 code for language",
-        example="FI",
+        description="ISO 639-1 code for language",
+        example="fi",
     )
     occupation_code: str = Field(
         ...,
         title="Occupation code",
-        description="Suomi.Fi code scheme",
+        description="Code scheme for occupation. Full set of codes can be found at https://koodistot.suomi.fi/codelist-api/api/v1/coderegistries/jhs/codeschemes/ammatti_1_20100101/codes/",
         example="11122",
     )
     citizenship_code: constr(min_length=2, max_length=2, to_upper=True) = Field(

--- a/src/test/lassipatanen/User/Profile.py
+++ b/src/test/lassipatanen/User/Profile.py
@@ -1,9 +1,15 @@
 from datetime import date, datetime
+from enum import Enum
 from typing import List, Optional
 from uuid import UUID
 
 from converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import Field, constr
+
+
+class Gender(str, Enum):
+    male = "MALE"
+    female = "FEMALE"
 
 
 class ProfileResponse(CamelCaseModel):
@@ -48,14 +54,14 @@ class ProfileResponse(CamelCaseModel):
         description="Date of Birth (date only)",
         example="2000-01-01",
     )
-    gender: str = Field(..., title="Gender", description="Gender")
-    country_of_birth_code: str = Field(
+    gender: Gender = Field(..., title="Gender", description="Gender of the user")
+    country_of_birth_code: constr(min_length=2, max_length=2, to_upper=True) = Field(
         ...,
         title="Country of birth code",
         description="ISO 3166-1 alpha-2 code for country",
         example="FI",
     )
-    native_language_code: str = Field(
+    native_language_code: constr(min_length=2, max_length=2, to_upper=True) = Field(
         ...,
         title="Native language code",
         description="ISO 3166-1 alpha-2 code for language",
@@ -67,7 +73,7 @@ class ProfileResponse(CamelCaseModel):
         description="Suomi.Fi code scheme",
         example="11122",
     )
-    citizenship_code: str = Field(
+    citizenship_code: constr(min_length=2, max_length=2, to_upper=True) = Field(
         ...,
         title="Nationality code",
         description="ISO 3166-1 alpha-2 code for nationality",

--- a/src/test/lassipatanen/User/Profile.py
+++ b/src/test/lassipatanen/User/Profile.py
@@ -1,0 +1,89 @@
+from datetime import date, datetime
+from typing import List, Optional
+from uuid import UUID
+
+from converter import CamelCaseModel, DataProductDefinition
+from pydantic import Field
+
+
+class ProfileResponse(CamelCaseModel):
+    id: UUID = Field(
+        title="Id",
+        description="uuid formatted string used to identify users",
+        example="cf57432e-809e-4353-adbd-9d5c0d733868",
+    )
+    created: datetime = Field(
+        title="Created",
+        description="Created at timestamp",
+        example="2042-04-23T10:20:30.400",
+    )
+    modified: datetime = Field(
+        title="Modified",
+        description="Modified at timestamp",
+        example="2042-04-23T10:20:30.400",
+    )
+    first_name: Optional[str] = Field(
+        ..., title="First name", description="First name of the user"
+    )
+    last_name: str = Field(..., title="Last name", description="Last name of the user")
+    address: str = Field(..., title="Address", description="Address of the user")
+    immigration_data_consent: bool = Field(
+        title="Immigration data consent",
+        description="Has user given permission to use their data on Registration of Foreigners application",
+        example=["true", "false"],
+    )
+    jobs_data_consent: bool = Field(
+        title="Jobs data consent",
+        description="Has user given permission to use their data on form application",
+    )
+    date_of_birth: date = Field(
+        ...,
+        title="Date of Birth",
+        description="Date of Birth (date only)",
+        example="1.1.2000",
+    )
+    gender: str = Field(..., title="Gender", description="Gender")
+    country_of_birth_iso_code: str = Field(
+        ...,
+        title="Country of Birth",
+        description="ISO 3166-1 alpha-2 code for country",
+        example="FI",
+    )
+    native_language_iso_code: str = Field(
+        ...,
+        title="Native language ISO code",
+        description="ISO 3166-1 alpha-2 code for language",
+        example="FI",
+    )
+    occupation_iso_code: str = Field(
+        ..., title="Occupation code", description="Suomi.Fi code scheme"
+    )
+    nationality_iso_code: str = Field(
+        ...,
+        title="Nationality ISO code",
+        description="ISO 3166-1 alpha-2 code for nationality",
+        example="FI",
+    )
+    job_titles: Optional[List[str]] = Field(
+        title="Job titles",
+        description="List of job titles",
+        example=["Chef", "Programmer"],
+    )
+    regions: Optional[List[str]] = Field(
+        title="Regions",
+        description="List of regions where user would want to search for a job",
+        example=["Etelä-Suomi"],
+    )
+
+
+class ProfileRequest(CamelCaseModel):
+    ...
+
+
+DEFINITION = DataProductDefinition(
+    description="Data product for basic user profile information",
+    request=ProfileRequest,
+    response=ProfileResponse,
+    route_description="User profile information",
+    summary="Basic user profile information",
+)

--- a/src/test/lassipatanen/User/Profile.py
+++ b/src/test/lassipatanen/User/Profile.py
@@ -77,7 +77,7 @@ class ProfileResponse(CamelCaseModel):
         description="ISO 3166-1 alpha-2 code for country",
         example="FI",
     )
-    native_language_code: constr(min_length=2, max_length=2, to_upper=True) = Field(
+    native_language_code: constr(min_length=2, max_length=2, to_lower=True) = Field(
         ...,
         title="Native language code",
         description="ISO 639-1 code for language",

--- a/src/test/lassipatanen/User/Profile.py
+++ b/src/test/lassipatanen/User/Profile.py
@@ -70,6 +70,7 @@ class ProfileResponse(CamelCaseModel):
         example=["Chef", "Programmer"],
     )
     regions: Optional[List[str]] = Field(
+        ...,
         title="Regions",
         description="List of regions where user would want to search for a job",
         example=["Etelä-Suomi"],


### PR DESCRIPTION
This is not the final data product but something that we need for testing purposes moving forward. Some fields, such as those consent related, will be removed once the final definition will be ready.

For language code I added regex costraint, as setting pydantic to_lower property didn't seem to affect the generated open api spec file in any way.