### PR TITLE
Change language code to be in ISO 639-3 format and remove consent fields in user profile

### DIFF
--- a/DataProducts/test/lassipatanen/User/Profile.json
+++ b/DataProducts/test/lassipatanen/User/Profile.json
@@ -240,12 +240,12 @@
           },
           "nativeLanguageCode": {
             "title": "Native language code",
-            "maxLength": 2,
-            "minLength": 2,
+            "maxLength": 3,
+            "minLength": 3,
             "type": "string",
-            "description": "ISO 639-1 code for language",
+            "description": "ISO 639-3 code for language",
             "nullable": true,
-            "example": "fi"
+            "example": "fin"
           },
           "occupationCode": {
             "title": "Occupation code",

--- a/DataProducts/test/lassipatanen/User/Profile.json
+++ b/DataProducts/test/lassipatanen/User/Profile.json
@@ -145,16 +145,7 @@
       },
       "ProfileResponse": {
         "title": "ProfileResponse",
-        "required": [
-          "id",
-          "created",
-          "modified",
-          "address",
-          "immigrationDataConsent",
-          "jobsDataConsent",
-          "jobTitles",
-          "regions"
-        ],
+        "required": ["id", "created", "modified", "address", "jobTitles", "regions"],
         "type": "object",
         "properties": {
           "id": {
@@ -200,16 +191,6 @@
               }
             ],
             "description": "Address of the user"
-          },
-          "immigrationDataConsent": {
-            "title": "Immigration data consent",
-            "type": "boolean",
-            "description": "Has user given permission to use their data on Registration of Foreigners application"
-          },
-          "jobsDataConsent": {
-            "title": "Jobs data consent",
-            "type": "boolean",
-            "description": "Has user given permission to use their data on form application"
           },
           "dateOfBirth": {
             "title": "Date of birth",

--- a/src/test/lassipatanen/User/Profile.py
+++ b/src/test/lassipatanen/User/Profile.py
@@ -75,14 +75,6 @@ class ProfileResponse(CamelCaseModel):
         nullable=True,
     )
     address: Address = Field(..., title="Address", description="Address of the user")
-    immigration_data_consent: bool = Field(
-        title="Immigration data consent",
-        description="Has user given permission to use their data on Registration of Foreigners application",
-    )
-    jobs_data_consent: bool = Field(
-        title="Jobs data consent",
-        description="Has user given permission to use their data on form application",
-    )
     date_of_birth: Optional[date] = Field(
         None,
         title="Date of birth",

--- a/src/test/lassipatanen/User/Profile.py
+++ b/src/test/lassipatanen/User/Profile.py
@@ -104,15 +104,15 @@ class ProfileResponse(CamelCaseModel):
     )
     native_language_code: Optional[
         constr(
-            min_length=2,
-            max_length=2,
+            min_length=3,
+            max_length=3,
             to_lower=True,
         )
     ] = Field(
         None,
         title="Native language code",
-        description="ISO 639-1 code for language",
-        example="fi",
+        description="ISO 639-3 code for language",
+        example="fin",
         nullable=True,
     )
     occupation_code: Optional[str] = Field(


### PR DESCRIPTION
Changed language code to be in ISO 639-3 format and removed consent fields that were used previously for testing stuff.