### PR TITLE
Fix field names for Admin Unit Levels in NSG / ... / SignatoryRights and Establishment

### DIFF
--- a/DataProducts/draft/NSG/Agent/LegalEntity/NonListedCompany/Establishment/Write.json
+++ b/DataProducts/draft/NSG/Agent/LegalEntity/NonListedCompany/Establishment/Write.json
@@ -245,7 +245,7 @@
             "description": "A location designator for a postal delivery point at a post office, usually a number.",
             "example": "9383"
           },
-          "adminUnitLevel_1": {
+          "adminUnitLevel1": {
             "title": "Admin unit level 1",
             "allOf": [
               {
@@ -255,7 +255,7 @@
             "description": "The name of the uppermost level of the address, almost always a country. ISO 3166 three character (Alpha 3) format.",
             "example": "USA"
           },
-          "adminUnitLevel_2": {
+          "adminUnitLevel2": {
             "title": "Admin unit level 2",
             "maxLength": 40,
             "type": "string",

--- a/DataProducts/draft/NSG/Agent/LegalEntity/NonListedCompany/SignatoryRights.json
+++ b/DataProducts/draft/NSG/Agent/LegalEntity/NonListedCompany/SignatoryRights.json
@@ -483,7 +483,7 @@
             "description": "A location designator for a postal delivery point at a post office, usually a number.",
             "example": "9383"
           },
-          "adminUnitLevel_1": {
+          "adminUnitLevel1": {
             "title": "Admin unit level 1",
             "allOf": [
               {
@@ -493,7 +493,7 @@
             "description": "The name of the uppermost level of the address, almost always a country. ISO 3166 three character (Alpha 3) format.",
             "example": "USA"
           },
-          "adminUnitLevel_2": {
+          "adminUnitLevel2": {
             "title": "Admin unit level 2",
             "maxLength": 40,
             "type": "string",

--- a/src/draft/NSG/Agent/LegalEntity/NonListedCompany/Establishment/Write.py
+++ b/src/draft/NSG/Agent/LegalEntity/NonListedCompany/Establishment/Write.py
@@ -1449,6 +1449,7 @@ class CompanyAddress(CamelCaseModel):
     )
     admin_unit_level_1: Optional[ISO_3166_1_Alpha_3] = Field(
         None,
+        alias="adminUnitLevel1",
         title="Admin unit level 1",
         description="The name of the uppermost level of the address, almost always a country. ISO 3166 three "
         "character (Alpha 3) format.",
@@ -1456,6 +1457,7 @@ class CompanyAddress(CamelCaseModel):
     )
     admin_unit_level_2: Optional[str] = Field(
         None,
+        alias="adminUnitLevel2",
         title="Admin unit level 2",
         description="The name of a secondary level/region of the address, usually a county, state or other such area "
         "that typically encompasses several localities. Values could be a region or province, "

--- a/src/draft/NSG/Agent/LegalEntity/NonListedCompany/SignatoryRights.py
+++ b/src/draft/NSG/Agent/LegalEntity/NonListedCompany/SignatoryRights.py
@@ -380,6 +380,7 @@ class SignatoryRights(CamelCaseModel):
     )
     admin_unit_level_1: Optional[ISO_3166_1_Alpha_3] = Field(
         None,
+        alias="adminUnitLevel1",
         title="Admin unit level 1",
         description="The name of the uppermost level of the address, almost always a country. ISO 3166 three "
         "character (Alpha 3) format.",
@@ -387,6 +388,7 @@ class SignatoryRights(CamelCaseModel):
     )
     admin_unit_level_2: Optional[str] = Field(
         None,
+        alias="adminUnitLevel2",
         title="Admin unit level 2",
         description="The name of a secondary level/region of the address, usually a county, state or other such area "
         "that typically encompasses several localities. Values could be a region or province, "


### PR DESCRIPTION
The conversion of the snake_cased field name to camelCase didn't work correctly when the name included a number.