### PR TITLE
More improvements to Employment/ForeignerJobRecommendations

### DIFF
--- a/DataProducts/Employment/ForeignerJobRecommendatations_v1.0.json
+++ b/DataProducts/Employment/ForeignerJobRecommendatations_v1.0.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Foreigner Job Recommendations",
     "description": "Returns the list of jobs recommended for the foreigner based on e.g. the citizenship area and previous occupations based on the European Standard Classification of Occupations (ESCO) version 1.1.1",
-    "version": "1.0.2"
+    "version": "1.0.1"
   },
   "paths": {
     "/Employment/ForeignerJobRecommendatations_v1.0": {
@@ -607,7 +607,7 @@
               {
                 "items": {
                   "type": "string",
-                  "pattern": "^[0-9]{1,3}$|^[0-9]{4}(\\.(?:([1-9]|[1-9][0-9]))){0,4}$"
+                  "pattern": "^[0-9]{4}(\\.(?:([1-9]|[1-9][0-9]))){0,4}$"
                 },
                 "type": "array"
               },

--- a/DataProducts/Employment/ForeignerJobRecommendatations_v1.0.json
+++ b/DataProducts/Employment/ForeignerJobRecommendatations_v1.0.json
@@ -11,6 +11,7 @@
         "summary": "Foreigner Job Recommendations",
         "description": "Returns the list of jobs recommended for the foreigner based on e.g. the citizenship area and previous occupations based on the European Standard Classification of Occupations (ESCO) version 1.1.1",
         "operationId": "request_Employment_ForeignerJobRecommendatations_v1_0",
+        "deprecated": true,
         "parameters": [
           {
             "name": "x-consent-token",

--- a/DataProducts/Employment/ForeignerJobRecommendatations_v1.0.json
+++ b/DataProducts/Employment/ForeignerJobRecommendatations_v1.0.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Foreigner Job Recommendations",
     "description": "Returns the list of jobs recommended for the foreigner based on e.g. the citizenship area and previous occupations based on the European Standard Classification of Occupations (ESCO) version 1.1.1",
-    "version": "1.0.1"
+    "version": "1.0.2"
   },
   "paths": {
     "/Employment/ForeignerJobRecommendatations_v1.0": {
@@ -607,7 +607,7 @@
               {
                 "items": {
                   "type": "string",
-                  "pattern": "^[0-9]{4}(\\.(?:([1-9]|[1-9][0-9]))){0,4}$"
+                  "pattern": "^[0-9]{1,3}$|^[0-9]{4}(\\.(?:([1-9]|[1-9][0-9]))){0,4}$"
                 },
                 "type": "array"
               },

--- a/DataProducts/Employment/ForeignerJobRecommendatations_v1.1.json
+++ b/DataProducts/Employment/ForeignerJobRecommendatations_v1.1.json
@@ -1,0 +1,883 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Foreigner Job Recommendations",
+    "description": "Returns the list of jobs recommended for the foreigner based on e.g. the citizenship area and previous occupations based on the European Standard Classification of Occupations (ESCO) version 1.1.1",
+    "version": "1.1.0"
+  },
+  "paths": {
+    "/Employment/ForeignerJobRecommendatations_v1.1": {
+      "post": {
+        "summary": "Foreigner Job Recommendations",
+        "description": "Returns the list of jobs recommended for the foreigner based on e.g. the citizenship area and previous occupations based on the European Standard Classification of Occupations (ESCO) version 1.1.1",
+        "operationId": "request_Employment_ForeignerJobRecommendatations_v1_1",
+        "parameters": [
+          {
+            "name": "x-consent-token",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Optional consent token",
+              "default": "",
+              "title": "X-Consent-Token"
+            },
+            "description": "Optional consent token"
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "The login token. Value should be \"Bearer [token]\"",
+              "default": "",
+              "title": "Authorization"
+            },
+            "description": "The login token. Value should be \"Bearer [token]\""
+          },
+          {
+            "name": "x-authorization-provider",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The bare domain of the system that provided the token.",
+              "title": "X-Authorization-Provider"
+            },
+            "description": "The bare domain of the system that provided the token."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ForeignerJobRecommendationsRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ForeignerJobRecommendationsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Unauthorized"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Forbidden"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFound"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "444": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DataSourceNotFound"
+                }
+              }
+            },
+            "description": "Additional Response"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DataSourceError"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadGateway"
+                }
+              }
+            },
+            "description": "Bad Gateway"
+          },
+          "503": {
+            "content": {
+              "text/plain": {},
+              "text/html": {},
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailable"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          },
+          "504": {
+            "content": {
+              "text/plain": {},
+              "text/html": {},
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GatewayTimeout"
+                }
+              }
+            },
+            "description": "Gateway Timeout"
+          },
+          "550": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DoesNotConformToDefinition"
+                }
+              }
+            },
+            "description": "Additional Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "BadGateway": {
+        "properties": {},
+        "type": "object",
+        "title": "BadGateway",
+        "description": "This response is reserved by Product Gateway."
+      },
+      "CitizenshipArea": {
+        "type": "string",
+        "enum": ["EEA", "non-EEA"],
+        "title": "CitizenshipArea"
+      },
+      "DataSourceError": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "title": "Error type",
+            "description": "Error identifier"
+          },
+          "message": {
+            "type": "string",
+            "title": "Error message",
+            "description": "Error description"
+          }
+        },
+        "type": "object",
+        "required": ["type", "message"],
+        "title": "DataSourceError"
+      },
+      "DataSourceNotFound": {
+        "properties": {
+          "message": {
+            "type": "string",
+            "title": "Error message",
+            "description": "Error description",
+            "default": "Data source not found"
+          }
+        },
+        "type": "object",
+        "title": "DataSourceNotFound",
+        "description": "This response is reserved by Product Gateway."
+      },
+      "DoesNotConformToDefinition": {
+        "properties": {
+          "message": {
+            "type": "string",
+            "title": "Message",
+            "default": "Response from data source does not conform to definition"
+          },
+          "data_source_status_code": {
+            "type": "integer",
+            "title": "Data source status code",
+            "description": "HTTP status code returned from the data source"
+          }
+        },
+        "type": "object",
+        "required": ["data_source_status_code"],
+        "title": "DoesNotConformToDefinition",
+        "description": "This response is reserved by Product Gateway."
+      },
+      "Employer": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 250,
+            "title": "Name",
+            "description": "Then name of the employer issuing the job advertisement",
+            "examples": ["Company Oy"]
+          },
+          "logoURL": {
+            "type": "string",
+            "maxLength": 2083,
+            "minLength": 1,
+            "format": "uri",
+            "title": "Logo URL",
+            "description": "The image URL of the employer logo",
+            "examples": ["https://example.com/image.jpg"]
+          }
+        },
+        "type": "object",
+        "required": ["name", "logoURL"],
+        "title": "Employer"
+      },
+      "FinnishMunicipality": {
+        "type": "string",
+        "enum": [
+          "020",
+          "005",
+          "009",
+          "010",
+          "016",
+          "018",
+          "019",
+          "035",
+          "043",
+          "046",
+          "047",
+          "049",
+          "050",
+          "051",
+          "052",
+          "060",
+          "061",
+          "062",
+          "065",
+          "069",
+          "071",
+          "072",
+          "074",
+          "075",
+          "076",
+          "077",
+          "078",
+          "079",
+          "081",
+          "082",
+          "086",
+          "111",
+          "090",
+          "091",
+          "097",
+          "098",
+          "102",
+          "103",
+          "105",
+          "106",
+          "108",
+          "109",
+          "139",
+          "140",
+          "142",
+          "143",
+          "145",
+          "146",
+          "153",
+          "148",
+          "149",
+          "151",
+          "152",
+          "165",
+          "167",
+          "169",
+          "170",
+          "171",
+          "172",
+          "176",
+          "177",
+          "178",
+          "179",
+          "181",
+          "182",
+          "186",
+          "202",
+          "204",
+          "205",
+          "208",
+          "211",
+          "213",
+          "214",
+          "216",
+          "217",
+          "218",
+          "224",
+          "226",
+          "230",
+          "231",
+          "232",
+          "233",
+          "235",
+          "236",
+          "239",
+          "240",
+          "320",
+          "241",
+          "322",
+          "244",
+          "245",
+          "249",
+          "250",
+          "256",
+          "257",
+          "260",
+          "261",
+          "263",
+          "265",
+          "271",
+          "272",
+          "273",
+          "275",
+          "276",
+          "280",
+          "284",
+          "285",
+          "286",
+          "287",
+          "288",
+          "290",
+          "291",
+          "295",
+          "297",
+          "300",
+          "301",
+          "304",
+          "305",
+          "312",
+          "316",
+          "317",
+          "318",
+          "398",
+          "399",
+          "400",
+          "407",
+          "402",
+          "403",
+          "405",
+          "408",
+          "410",
+          "416",
+          "417",
+          "418",
+          "420",
+          "421",
+          "422",
+          "423",
+          "425",
+          "426",
+          "444",
+          "430",
+          "433",
+          "434",
+          "435",
+          "436",
+          "438",
+          "440",
+          "441",
+          "475",
+          "478",
+          "480",
+          "481",
+          "483",
+          "484",
+          "489",
+          "491",
+          "494",
+          "495",
+          "498",
+          "499",
+          "500",
+          "503",
+          "504",
+          "505",
+          "508",
+          "507",
+          "529",
+          "531",
+          "535",
+          "536",
+          "538",
+          "541",
+          "543",
+          "545",
+          "560",
+          "561",
+          "562",
+          "563",
+          "564",
+          "309",
+          "576",
+          "577",
+          "578",
+          "445",
+          "580",
+          "581",
+          "599",
+          "583",
+          "854",
+          "584",
+          "588",
+          "592",
+          "593",
+          "595",
+          "598",
+          "601",
+          "604",
+          "607",
+          "608",
+          "609",
+          "611",
+          "638",
+          "614",
+          "615",
+          "616",
+          "619",
+          "620",
+          "623",
+          "624",
+          "625",
+          "626",
+          "630",
+          "631",
+          "635",
+          "636",
+          "678",
+          "710",
+          "680",
+          "681",
+          "683",
+          "684",
+          "686",
+          "687",
+          "689",
+          "691",
+          "694",
+          "697",
+          "698",
+          "700",
+          "702",
+          "704",
+          "707",
+          "729",
+          "732",
+          "734",
+          "736",
+          "790",
+          "738",
+          "739",
+          "740",
+          "742",
+          "743",
+          "746",
+          "747",
+          "748",
+          "791",
+          "749",
+          "751",
+          "753",
+          "755",
+          "758",
+          "759",
+          "761",
+          "762",
+          "765",
+          "766",
+          "768",
+          "771",
+          "777",
+          "778",
+          "781",
+          "783",
+          "831",
+          "832",
+          "833",
+          "834",
+          "837",
+          "844",
+          "845",
+          "846",
+          "848",
+          "849",
+          "850",
+          "851",
+          "853",
+          "857",
+          "858",
+          "859",
+          "886",
+          "887",
+          "889",
+          "890",
+          "892",
+          "893",
+          "895",
+          "785",
+          "905",
+          "908",
+          "092",
+          "915",
+          "918",
+          "921",
+          "922",
+          "924",
+          "925",
+          "927",
+          "931",
+          "934",
+          "935",
+          "936",
+          "941",
+          "946",
+          "976",
+          "977",
+          "980",
+          "981",
+          "989",
+          "992"
+        ],
+        "title": "FinnishMunicipality"
+      },
+      "Forbidden": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "title": "Error type",
+            "description": "Error identifier"
+          },
+          "message": {
+            "type": "string",
+            "title": "Error message",
+            "description": "Error description"
+          }
+        },
+        "type": "object",
+        "required": ["type", "message"],
+        "title": "Forbidden"
+      },
+      "ForeignerJobRecommendationsRequest": {
+        "properties": {
+          "escoCodes": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string",
+                  "pattern": "^[0-9]{1,3}$|^[0-9]{4}(\\.(?:([1-9]|[1-9][0-9]))){0,4}$"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "ESCO Codes",
+            "description": "The ESCO code based on the standard ESCO occupation classification",
+            "examples": [["8331.1"]]
+          },
+          "citizenshipArea": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/CitizenshipArea"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Citizenship Area",
+            "description": "The citizenship area based on his or her native country. Switzerland is considered as part of the EEA category.",
+            "examples": ["EEA"]
+          },
+          "preferredMunicipalities": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/FinnishMunicipality"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Preferred Municipalities",
+            "description": "The potential municipalities in Finland that the user desires to find a job from.",
+            "examples": [["091"]]
+          },
+          "freeText": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 250
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Free Text",
+            "description": "Free text that the user wants to use for filtering job advertisements",
+            "examples": ["Driving license"]
+          },
+          "limit": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 1.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Limit",
+            "description": "The limit of items per page in response",
+            "examples": [1000]
+          },
+          "offset": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Offset",
+            "description": "The starting index of responses",
+            "examples": [0]
+          }
+        },
+        "type": "object",
+        "title": "ForeignerJobRecommendationsRequest"
+      },
+      "ForeignerJobRecommendationsResponse": {
+        "properties": {
+          "identifier": {
+            "type": "string",
+            "title": "Identifier",
+            "description": "The job recommendation search identifier",
+            "examples": ["123e4567-e89b-12d3-a456-426614174000"]
+          },
+          "jobs": {
+            "items": {
+              "$ref": "#/components/schemas/Job"
+            },
+            "type": "array",
+            "title": "Jobs",
+            "description": "The list of jobs recommended for the foreigner based on the input properties"
+          },
+          "totalCount": {
+            "type": "integer",
+            "title": "Total Count",
+            "description": "The total count of job recommendations",
+            "examples": [47]
+          }
+        },
+        "type": "object",
+        "required": ["identifier", "jobs", "totalCount"],
+        "title": "ForeignerJobRecommendationsResponse"
+      },
+      "GatewayTimeout": {
+        "properties": {
+          "message": {
+            "type": "string",
+            "title": "Error message",
+            "description": "Error description",
+            "default": ""
+          }
+        },
+        "type": "object",
+        "title": "GatewayTimeout",
+        "description": "This response is reserved by Product Gateway."
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "Job": {
+        "properties": {
+          "title": {
+            "type": "string",
+            "maxLength": 250,
+            "title": "Title",
+            "description": "Title of the advertised job",
+            "examples": ["Item specialist"]
+          },
+          "score": {
+            "type": "number",
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "title": "Score",
+            "description": "The confidence score for the job advertisement recommendation",
+            "examples": [0.88]
+          },
+          "advertisementURL": {
+            "type": "string",
+            "maxLength": 2083,
+            "minLength": 1,
+            "format": "uri",
+            "title": "Advertisement URL",
+            "description": "The link to the service providing the job advertisement details",
+            "examples": ["https://jobadvertisement.example.com/ad123"]
+          },
+          "municipalityCode": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FinnishMunicipality"
+              }
+            ],
+            "title": "Municipality Code",
+            "description": "The location of the advertised job ",
+            "examples": ["091"]
+          },
+          "employer": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Employer"
+              }
+            ],
+            "description": "The details of an employer that issued the job advertisement"
+          }
+        },
+        "type": "object",
+        "required": [
+          "title",
+          "score",
+          "advertisementURL",
+          "municipalityCode",
+          "employer"
+        ],
+        "title": "Job"
+      },
+      "NotFound": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "title": "Error type",
+            "description": "Error identifier"
+          },
+          "message": {
+            "type": "string",
+            "title": "Error message",
+            "description": "Error description"
+          }
+        },
+        "type": "object",
+        "required": ["type", "message"],
+        "title": "NotFound"
+      },
+      "ServiceUnavailable": {
+        "properties": {
+          "message": {
+            "type": "string",
+            "title": "Error message",
+            "description": "Error description",
+            "default": ""
+          }
+        },
+        "type": "object",
+        "title": "ServiceUnavailable",
+        "description": "This response is reserved by Product Gateway."
+      },
+      "Unauthorized": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "title": "Error type",
+            "description": "Error identifier"
+          },
+          "message": {
+            "type": "string",
+            "title": "Error message",
+            "description": "Error description"
+          }
+        },
+        "type": "object",
+        "required": ["type", "message"],
+        "title": "Unauthorized"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": ["loc", "msg", "type"],
+        "title": "ValidationError"
+      }
+    }
+  }
+}

--- a/src/Employment/ForeignerJobRecommendatations_v1.0.py
+++ b/src/Employment/ForeignerJobRecommendatations_v1.0.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
 from pydantic import Field, HttpUrl, constr
 
-EscoCode = constr(pattern=r"^[0-9]{1,3}$|^[0-9]{4}(\.(?:([1-9]|[1-9][0-9]))){0,4}$")
+EscoCode = constr(pattern=r"^[0-9]{4}(\.(?:([1-9]|[1-9][0-9]))){0,4}$")
 
 
 class FinnishMunicipality(str, Enum):
@@ -445,7 +445,7 @@ class ForeignerJobRecommendationsResponse(CamelCaseModel):
 
 
 DEFINITION = DataProductDefinition(
-    version="1.0.2",
+    version="1.0.1",
     title="Foreigner Job Recommendations",
     description="Returns the list of jobs recommended for the foreigner based on e.g. "
     "the citizenship area and previous occupations based on the European Standard "

--- a/src/Employment/ForeignerJobRecommendatations_v1.0.py
+++ b/src/Employment/ForeignerJobRecommendatations_v1.0.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
 from pydantic import Field, HttpUrl, constr
 
-EscoCode = constr(pattern=r"^[0-9]{4}(\.(?:([1-9]|[1-9][0-9]))){0,4}$")
+EscoCode = constr(pattern=r"^[0-9]{1,3}$|^[0-9]{4}(\.(?:([1-9]|[1-9][0-9]))){0,4}$")
 
 
 class FinnishMunicipality(str, Enum):
@@ -445,7 +445,7 @@ class ForeignerJobRecommendationsResponse(CamelCaseModel):
 
 
 DEFINITION = DataProductDefinition(
-    version="1.0.1",
+    version="1.0.2",
     title="Foreigner Job Recommendations",
     description="Returns the list of jobs recommended for the foreigner based on e.g. "
     "the citizenship area and previous occupations based on the European Standard "

--- a/src/Employment/ForeignerJobRecommendatations_v1.0.py
+++ b/src/Employment/ForeignerJobRecommendatations_v1.0.py
@@ -446,6 +446,7 @@ class ForeignerJobRecommendationsResponse(CamelCaseModel):
 
 DEFINITION = DataProductDefinition(
     version="1.0.1",
+    deprecated=True,
     title="Foreigner Job Recommendations",
     description="Returns the list of jobs recommended for the foreigner based on e.g. "
     "the citizenship area and previous occupations based on the European Standard "

--- a/src/Employment/ForeignerJobRecommendatations_v1.1.py
+++ b/src/Employment/ForeignerJobRecommendatations_v1.1.py
@@ -1,0 +1,457 @@
+from enum import Enum
+from typing import List, Optional
+
+from definition_tooling.converter import CamelCaseModel, DataProductDefinition
+from pydantic import Field, HttpUrl, constr
+
+EscoCode = constr(pattern=r"^[0-9]{1,3}$|^[0-9]{4}(\.(?:([1-9]|[1-9][0-9]))){0,4}$")
+
+
+class FinnishMunicipality(str, Enum):
+    AKAA = "020"
+    ALAJARVI = "005"
+    ALAVIESKA = "009"
+    ALAVUS = "010"
+    ASIKKALA = "016"
+    ASKOLA = "018"
+    AURA = "019"
+    BRANDO = "035"
+    ECKERO = "043"
+    ENONKOSKI = "046"
+    ENONTEKIO = "047"
+    ESPOO = "049"
+    EURA = "050"
+    EURAJOKI = "051"
+    EVIJARVI = "052"
+    FINSTROM = "060"
+    FORSSA = "061"
+    FOGLO = "062"
+    GETA = "065"
+    HAAPAJARVI = "069"
+    HAAPAVESI = "071"
+    HAILUOTO = "072"
+    HALSUA = "074"
+    HAMINA = "075"
+    HAMMARLAND = "076"
+    HANKASALMI = "077"
+    HANKO = "078"
+    HARJAVALTA = "079"
+    HARTOLA = "081"
+    HATTULA = "082"
+    HAUSJARVI = "086"
+    HEINOLA = "111"
+    HEINAVESI = "090"
+    HELSINKI = "091"
+    HIRVENSALMI = "097"
+    HOLLOLA = "098"
+    HUITTINEN = "102"
+    HUMPPILA = "103"
+    HYRYNSALMI = "105"
+    HYVINKAA = "106"
+    HAMEENKYRO = "108"
+    HAMEENLINNA = "109"
+    II = "139"
+    IISALMI = "140"
+    IITTI = "142"
+    IKAALINEN = "143"
+    ILMAJOKI = "145"
+    ILOMANTSI = "146"
+    IMATRA = "153"
+    INARI = "148"
+    INKOO = "149"
+    ISOJOKI = "151"
+    ISOKYRO = "152"
+    JANAKKALA = "165"
+    JOENSUU = "167"
+    JOKIOINEN = "169"
+    JOMALA = "170"
+    JOROINEN = "171"
+    JOUTSA = "172"
+    JUUKA = "176"
+    JUUPAJOKI = "177"
+    JUVA = "178"
+    JYVASKYLA = "179"
+    JAMIJARVI = "181"
+    JAMSA = "182"
+    JARVENPAA = "186"
+    KAARINA = "202"
+    KAAVI = "204"
+    KAJAANI = "205"
+    KALAJOKI = "208"
+    KANGASALA = "211"
+    KANGASNIEMI = "213"
+    KANKAANPAA = "214"
+    KANNONKOSKI = "216"
+    KANNUS = "217"
+    KARIJOKI = "218"
+    KARKKILA = "224"
+    KARSTULA = "226"
+    KARVIA = "230"
+    KASKINEN = "231"
+    KAUHAJOKI = "232"
+    KAUHAVA = "233"
+    KAUNIAINEN = "235"
+    KAUSTINEN = "236"
+    KEITELE = "239"
+    KEMI = "240"
+    KEMIJARVI = "320"
+    KEMINMAA = "241"
+    KEMIONSAARI = "322"
+    KEMPELE = "244"
+    KERAVA = "245"
+    KEURUU = "249"
+    KIHNIO = "250"
+    KINNULA = "256"
+    KIRKKONUMMI = "257"
+    KITEE = "260"
+    KITTILA = "261"
+    KIURUVESI = "263"
+    KIVIJARVI = "265"
+    KOKEMAKI = "271"
+    KOKKOLA = "272"
+    KOLARI = "273"
+    KONNEVESI = "275"
+    KONTIOLAHTI = "276"
+    KORSNAS = "280"
+    KOSKI_TL = "284"
+    KOTKA = "285"
+    KOUVOLA = "286"
+    KRISTIINANKAUPUNKI = "287"
+    KRUUNUPYY = "288"
+    KUHMO = "290"
+    KUHMOINEN = "291"
+    KUMLINGE = "295"
+    KUOPIO = "297"
+    KUORTANE = "300"
+    KURIKKA = "301"
+    KUSTAVI = "304"
+    KUUSAMO = "305"
+    KYYJARVI = "312"
+    KARKOLA = "316"
+    KARSAMAKI = "317"
+    KOKAR = "318"
+    LAHTI = "398"
+    LAIHIA = "399"
+    LAITILA = "400"
+    LAPINJARVI = "407"
+    LAPINLAHTI = "402"
+    LAPPAJARVI = "403"
+    LAPPEENRANTA = "405"
+    LAPUA = "408"
+    LAUKAA = "410"
+    LEMI = "416"
+    LEMLAND = "417"
+    LEMPAALA = "418"
+    LEPPAVIRTA = "420"
+    LESTIJARVI = "421"
+    LIEKSA = "422"
+    LIETO = "423"
+    LIMINKA = "425"
+    LIPERI = "426"
+    LOHJA = "444"
+    LOIMAA = "430"
+    LOPPI = "433"
+    LOVIISA = "434"
+    LUHANKA = "435"
+    LUMIJOKI = "436"
+    LUMPARLAND = "438"
+    LUOTO = "440"
+    LUUMAKI = "441"
+    MAALAHTI = "475"
+    MAARIANHAMINA = "478"
+    MARTTILA = "480"
+    MASKU = "481"
+    MERIJARVI = "483"
+    MERIKARVIA = "484"
+    MIEHIKKALA = "489"
+    MIKKELI = "491"
+    MUHOS = "494"
+    MULTIA = "495"
+    MUONIO = "498"
+    MUSTASAARI = "499"
+    MUURAME = "500"
+    MYNAMAKI = "503"
+    MYRSKYLA = "504"
+    MANTSALA = "505"
+    MANTTA_VILPPULA = "508"
+    MANTYHARJU = "507"
+    NAANTALI = "529"
+    NAKKILA = "531"
+    NIVALA = "535"
+    NOKIA = "536"
+    NOUSIAINEN = "538"
+    NURMES = "541"
+    NURMIJARVI = "543"
+    NARPIO = "545"
+    ORIMATTILA = "560"
+    ORIPAA = "561"
+    ORIVESI = "562"
+    OULAINEN = "563"
+    OULU = "564"
+    OUTOKUMPU = "309"
+    PADASJOKI = "576"
+    PAIMIO = "577"
+    PALTAMO = "578"
+    PARAINEN = "445"
+    PARIKKALA = "580"
+    PARKANO = "581"
+    PEDERSOREN_KUNTA = "599"
+    PELKOSENNIEMI = "583"
+    PELLO = "854"
+    PERHO = "584"
+    PERTUNMAA = "588"
+    PETAJAVESI = "592"
+    PIEKSAMAKI = "593"
+    PIELAVESI = "595"
+    PIETARSAARI = "598"
+    PIHTIPUDAS = "601"
+    PIRKKALA = "604"
+    POLVIJARVI = "607"
+    POMARKKU = "608"
+    PORI = "609"
+    PORNAINEN = "611"
+    PORVOO = "638"
+    POSIO = "614"
+    PUDASJARVI = "615"
+    PUKKILA = "616"
+    PUNKALAIDUN = "619"
+    PUOLANKA = "620"
+    PUUMALA = "623"
+    PYHTAA = "624"
+    PYHAJOKI = "625"
+    PYHAJARVI = "626"
+    PYHANTA = "630"
+    PYHARANTA = "631"
+    PALKANE = "635"
+    POYTYA = "636"
+    RAAHE = "678"
+    RAASEPORI = "710"
+    RAISIO = "680"
+    RANTASALMI = "681"
+    RANUA = "683"
+    RAUMA = "684"
+    RAUTALAMPI = "686"
+    RAUTAVAARA = "687"
+    RAUTJARVI = "689"
+    REISJARVI = "691"
+    RIIHIMAKI = "694"
+    RISTIJARVI = "697"
+    ROVANIEMI = "698"
+    RUOKOLAHTI = "700"
+    RUOVESI = "702"
+    RUSKO = "704"
+    RAAKKYLA = "707"
+    SAARIJARVI = "729"
+    SALLA = "732"
+    SALO = "734"
+    SALTVIK = "736"
+    SASTAMALA = "790"
+    SAUVO = "738"
+    SAVITAIPALE = "739"
+    SAVONLINNA = "740"
+    SAVUKOSKI = "742"
+    SEINAJOKI = "743"
+    SIEVI = "746"
+    SIIKAINEN = "747"
+    SIIKAJOKI = "748"
+    SIIKALATVA = "791"
+    SIILINJARVI = "749"
+    SIMO = "751"
+    SIPOO = "753"
+    SIUNTIO = "755"
+    SODANKYLA = "758"
+    SOINI = "759"
+    SOMERO = "761"
+    SONKAJARVI = "762"
+    SOTKAMO = "765"
+    SOTTUNGA = "766"
+    SULKAVA = "768"
+    SUND = "771"
+    SUOMUSSALMI = "777"
+    SUONENJOKI = "778"
+    SYSMA = "781"
+    SAKYLA = "783"
+    TAIPALSAARI = "831"
+    TAIVALKOSKI = "832"
+    TAIVASSALO = "833"
+    TAMMELA = "834"
+    TAMPERE = "837"
+    TERVO = "844"
+    TERVOLA = "845"
+    TEUVA = "846"
+    TOHMAJARVI = "848"
+    TOHOLAMPI = "849"
+    TOIVAKKA = "850"
+    TORNIO = "851"
+    TURKU = "853"
+    TUUSNIEMI = "857"
+    TUUSULA = "858"
+    TYRNAVA = "859"
+    ULVILA = "886"
+    URJALA = "887"
+    UTAJARVI = "889"
+    UTSJOKI = "890"
+    UURAINEN = "892"
+    UUSIKAARLEPYY = "893"
+    UUSIKAUPUNKI = "895"
+    VAALA = "785"
+    VAASA = "905"
+    VALKEAKOSKI = "908"
+    VANTAA = "092"
+    VARKAUS = "915"
+    VEHMAA = "918"
+    VESANTO = "921"
+    VESILAHTI = "922"
+    VETELI = "924"
+    VIEREMA = "925"
+    VIHTI = "927"
+    VIITASAARI = "931"
+    VIMPELI = "934"
+    VIROLAHTI = "935"
+    VIRRAT = "936"
+    VARDO = "941"
+    VOYRI = "946"
+    YLITORNIO = "976"
+    YLIVIESKA = "977"
+    YLOJARVI = "980"
+    YPAJA = "981"
+    AHTARI = "989"
+    AANEKOSKI = "992"
+
+
+class CitizenshipArea(str, Enum):
+    EEA = "EEA"
+    NON_EEA = "non-EEA"
+
+
+class ForeignerJobRecommendationsRequest(CamelCaseModel):
+    esco_codes: Optional[List[EscoCode]] = Field(
+        None,
+        title="ESCO Codes",
+        description="The ESCO code based on the standard ESCO occupation "
+        "classification",
+        examples=[["8331.1"]],
+    )
+    citizenship_area: Optional[CitizenshipArea] = Field(
+        None,
+        title="Citizenship Area",
+        description="The citizenship area based on his or her native country. "
+        "Switzerland is considered as part of the EEA category.",
+        examples=[CitizenshipArea.EEA],
+    )
+    preferred_municipalities: Optional[List[FinnishMunicipality]] = Field(
+        None,
+        title="Preferred Municipalities",
+        description="The potential municipalities in Finland that the user desires to "
+        "find a job from.",
+        examples=[[FinnishMunicipality.HELSINKI]],
+    )
+    free_text: Optional[str] = Field(
+        None,
+        title="Free Text",
+        description="Free text that the user wants to use for filtering job "
+        "advertisements",
+        max_length=250,
+        examples=["Driving license"],
+    )
+    limit: Optional[int] = Field(
+        None,
+        title="Limit",
+        description="The limit of items per page in response",
+        ge=1,
+        examples=[1000],
+    )
+    offset: Optional[int] = Field(
+        None,
+        title="Offset",
+        description="The starting index of responses",
+        ge=0,
+        examples=[0],
+    )
+
+
+class Employer(CamelCaseModel):
+    name: str = Field(
+        ...,
+        title="Name",
+        description="Then name of the employer issuing the job advertisement",
+        max_length=250,
+        examples=["Company Oy"],
+    )
+    logo_url: HttpUrl = Field(
+        ...,
+        alias="logoURL",
+        title="Logo URL",
+        description="The image URL of the employer logo",
+        examples=["https://example.com/image.jpg"],
+    )
+
+
+class Job(CamelCaseModel):
+    title: str = Field(
+        ...,
+        title="Title",
+        description="Title of the advertised job",
+        max_length=250,
+        examples=["Item specialist"],
+    )
+    score: float = Field(
+        ...,
+        title="Score",
+        description="The confidence score for the job advertisement recommendation",
+        ge=0.0,
+        le=1.0,
+        examples=[0.88],
+    )
+    advertisement_url: HttpUrl = Field(
+        ...,
+        alias="advertisementURL",
+        title="Advertisement URL",
+        description="The link to the service providing the job advertisement details",
+        examples=["https://jobadvertisement.example.com/ad123"],
+    )
+    municipality_code: FinnishMunicipality = Field(
+        ...,
+        title="Municipality Code",
+        description="The location of the advertised job ",
+        examples=[FinnishMunicipality.HELSINKI],
+    )
+    employer: Employer = Field(
+        ...,
+        title="Employer",
+        description="The details of an employer that issued the job advertisement",
+    )
+
+
+class ForeignerJobRecommendationsResponse(CamelCaseModel):
+    identifier: str = Field(
+        ...,
+        title="Identifier",
+        description="The job recommendation search identifier",
+        examples=["123e4567-e89b-12d3-a456-426614174000"],
+    )
+    jobs: List[Job] = Field(
+        ...,
+        title="Jobs",
+        description="The list of jobs recommended for the foreigner based on the input "
+        "properties",
+    )
+    total_count: int = Field(
+        ...,
+        title="Total Count",
+        description="The total count of job recommendations",
+        examples=[47],
+    )
+
+
+DEFINITION = DataProductDefinition(
+    version="1.1.0",
+    title="Foreigner Job Recommendations",
+    description="Returns the list of jobs recommended for the foreigner based on e.g. "
+    "the citizenship area and previous occupations based on the European Standard "
+    "Classification of Occupations (ESCO) version 1.1.1",
+    request=ForeignerJobRecommendationsRequest,
+    response=ForeignerJobRecommendationsResponse,
+    requires_authorization=False,
+    requires_consent=False,
+)


### PR DESCRIPTION
Allow the ESCO codes to be 1-3 digits without dots in addition to the 4 digits in the new 1.1.0 version, mark the 1.0.x as deprecated.