### PR TITLE
Mark Employment/WorkContract_v0.1 as deprecated

### DIFF
--- a/DataProducts/Employment/WorkContract_v0.1.json
+++ b/DataProducts/Employment/WorkContract_v0.1.json
@@ -11,6 +11,7 @@
         "summary": "Employment Work Contract",
         "description": "Contents of a work contract",
         "operationId": "request_Employment_WorkContract_v0_1",
+        "deprecated": true,
         "parameters": [
           {
             "name": "x-consent-token",

--- a/src/Employment/WorkContract_v0.1.py
+++ b/src/Employment/WorkContract_v0.1.py
@@ -331,6 +331,7 @@ class WorkContractResponse(CamelCaseModel):
 
 DEFINITION = DataProductDefinition(
     version="0.1.0",
+    deprecated=True,
     title="Employment Work Contract",
     description="Contents of a work contract",
     request=WorkContractRequest,


### PR DESCRIPTION
I forgot to mark the v0.1 as deprecated when adding the v0.2.